### PR TITLE
Add Coordinate validation to Board

### DIFF
--- a/lib/board.rb
+++ b/lib/board.rb
@@ -8,8 +8,50 @@ class Board
     @cells = make_cells
   end
 
-  def valid_coordinate? coor 
+  def valid_coordinate?(coor) 
     @cells.keys.include? coor
+  end
+
+  def valid_placement?(ship, coors)
+    valid = coors.map {|coor| valid_coordinate?(coor)}
+    length(ship, coors) && order(ship, coors) && valid.all?
+  end
+
+  def length(ship, coors)
+    ship.length == coors.count
+  end
+
+  def order(ship, coors)
+    horizontal = make_horizontal(coors)
+    vertical = make_vert(coors)
+    
+    coors == horizontal || coors == vertical
+  end
+
+  def make_horizontal(coors)
+    coor = [coors[0]]
+    
+    def increment(num, coor)
+      coor << coor[num].succ
+    end
+
+    (coors.count-1).times do |i|
+      increment(i, coor)
+    end
+    coor 
+  end
+
+  def make_vert(coors)
+    coor = [coors[0]]
+    
+    def increment(num, coor)
+      coor << coor[num].split('')[0].succ + coor[0].split('')[1]
+    end
+
+    (coors.count-1).times do |i|
+      increment(i, coor)
+    end
+    coor 
   end
 
 end

--- a/lib/cell.rb
+++ b/lib/cell.rb
@@ -1,6 +1,6 @@
 require 'pry'
 class Cell
-attr_reader :coordinate, :ship, :fired_upon
+attr_reader :coordinate, :ship
 
   def initialize(coordinate)
     @coordinate = coordinate

--- a/test/board_test.rb
+++ b/test/board_test.rb
@@ -28,20 +28,19 @@ class BoardTest < Minitest::Test
   end
 
   def test_validate_placement_method_for_length_check
-    skip
     cruiser = Ship.new("Cruiser", 3)
     submarine = Ship.new("Submarine", 2)
     
-    assert_equal false, @board.valid_placement?(cruiser, ["A1", "A2"])
-    assert_equal true, @board.valid_placement?(cruiser, ["A1", "A2", "A3"])
+    assert_equal false, @board.length(cruiser, ["A1", "A2"])
+    assert_equal true, @board.length(cruiser, ["A1", "A2", "A3"])
 
-    assert_equal true, @board.valid_placement?(cruiser, ["A1", "A2"])
-    assert_equal false, @board.valid_placement?(cruiser, ["A1", "A2", "A3"])
+    assert_equal true, @board.length(submarine, ["A1", "A2"])
+    assert_equal false, @board.length(submarine, ["A1", "A2", "A3"])
   end
 
   def test_validate_placement_method_for_consecutive_coordinates
-    skip
     cruiser = Ship.new("Cruiser", 3)
+    submarine = Ship.new("Submarine", 2)
 
     assert_equal false, @board.valid_placement?(cruiser, ["A1", "A2", "A4"])
     assert_equal false, @board.valid_placement?(cruiser, ["A3", "A2", "A1"])
@@ -51,14 +50,14 @@ class BoardTest < Minitest::Test
     assert_equal true, @board.valid_placement?(cruiser, ["A1", "B1", "C1"])
     assert_equal true, @board.valid_placement?(cruiser, ["B2", "C2", "D2"])
 
-  end
-
-  def test_validate_placement_method_for_diagonal_coordinates
-    skip
-    cruiser = Ship.new("Cruiser", 3)
-
     assert_equal false, @board.valid_placement?(cruiser, ["A1", "B2", "C3"])
     assert_equal false, @board.valid_placement?(cruiser, ["B2", "C3", "D4"])
-  end
 
+    assert_equal false, @board.valid_placement?(cruiser, ["A1", "A3"])
+    assert_equal false, @board.valid_placement?(cruiser, ["A4", "A5"])
+    assert_equal false, @board.valid_placement?(cruiser, ["A4", ""])
+    assert_equal false, @board.valid_placement?(cruiser, [])
+    assert_equal true, @board.valid_placement?(submarine, ["A1", "A2"])
+    assert_equal true, @board.valid_placement?(submarine, ["A1", "B1"])
+  end
 end


### PR DESCRIPTION
Co-Authored-By: David Holtkamp <david.hholtkamp@gmail.com>

Added board ability to 
- Verify if ship length is equal to request placement length
- Verify it orientation is acceptable
- Verify if placement coordinates exist as a spot on the board